### PR TITLE
show modal only on youtube page

### DIFF
--- a/Extension/background.js
+++ b/Extension/background.js
@@ -692,6 +692,19 @@ function isProjectGitHubPage(url) {
     }
 }
 
+function isYoutubeUrl(url) {
+    if (!url) return false;
+    try {
+        const u = new URL(url);
+        const host = String(u.hostname || '').toLowerCase();
+        return host === 'youtube.com'
+            || host === 'www.youtube.com'
+            || host === 'music.youtube.com';
+    } catch {
+        return false;
+    }
+}
+
 async function sendRequestSyncWithRetries(tabId, expectedUrl, maxAttempts = 18, extraFields = {}) {
     if (!tabId) return false;
 
@@ -724,6 +737,8 @@ async function tryShowPendingUpdateModal(tabId, url) {
     const isNativeBlocking = pendingUpdateModal.kind === 'native_missing' || pendingUpdateModal.kind === 'native_invalid';
     if (!isNativeBlocking && updateModalTargetTabId && tabId !== updateModalTargetTabId) return;
     if (!isDisplayableUrl(url)) return;
+
+    if (isNativeBlocking && !isYoutubeOrMusicUrl(url)) return;
 
     // Don't show "Native App Not Installed" on the project's GitHub page
     if (isNativeBlocking && isProjectGitHubPage(url)) return;
@@ -759,6 +774,7 @@ function scheduleTryShowUpdateModal(tabId, url) {
     const isNativeBlocking = pendingUpdateModal.kind === 'native_missing' || pendingUpdateModal.kind === 'native_invalid';
     if (!isNativeBlocking && updateModalTargetTabId && tabId !== updateModalTargetTabId) return;
     if (!isDisplayableUrl(url)) return;
+    if (isNativeBlocking && !isYoutubeOrMusicUrl(url)) return;
 
     const maxAttempts = 40;
     const current = updateModalRetryByTab.get(tabId);

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -681,17 +681,6 @@ function isDisplayableUrl(url) {
     }
 }
 
-function isProjectGitHubPage(url) {
-    if (!url) return false;
-    try {
-        const u = new URL(url);
-        return u.hostname === 'github.com' &&
-            u.pathname.toLowerCase().startsWith('/enhanced-discord-rich-presence/');
-    } catch {
-        return false;
-    }
-}
-
 function isYoutubeUrl(url) {
     if (!url) return false;
     try {
@@ -739,9 +728,6 @@ async function tryShowPendingUpdateModal(tabId, url) {
     if (!isDisplayableUrl(url)) return;
 
     if (isNativeBlocking && !isYoutubeOrMusicUrl(url)) return;
-
-    // Don't show "Native App Not Installed" on the project's GitHub page
-    if (isNativeBlocking && isProjectGitHubPage(url)) return;
 
     if (isNativeBlocking) {
         const status = await probeNativeHost();

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -48,7 +48,7 @@
       "run_at": "document_idle"
     },
     {
-      "matches": ["<all_urls>"],
+      "matches": ["*://*.youtube.com/*", "*://music.youtube.com/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
This pull request updates the logic for displaying the "Native App Not Installed" modal in the browser extension, restricting it to only appear on YouTube-related pages. This change ensures that users are only prompted about native app issues when they are on YouTube or YouTube Music, reducing unnecessary interruptions elsewhere.

I don't think it's a good idea to display the modal on every page not related to YouTube.