### PR TITLE
fix various issues for the extension

### DIFF
--- a/App/bridge.py
+++ b/App/bridge.py
@@ -475,7 +475,11 @@ def main():
                                     bridge._render_rpc(last_msg)
                                     continue
                             
-                            active_cfg = youtube_settings.get("running", {})
+                            last_action = last_msg.get("action")
+                            if last_action == "VIDEO_PAUSED":
+                                active_cfg = youtube_settings.get("paused", {})
+                            else:
+                                active_cfg = youtube_settings.get("running", {})
                         last_msg["settings"] = active_cfg
                         bridge._render_rpc(last_msg)
 

--- a/App/bridge.py
+++ b/App/bridge.py
@@ -233,7 +233,8 @@ class MultiServiceBridge:
                 
                 if end_val:
                     if isinstance(end_val, bool):
-                        timestamps["end"] = int(now + (total_duration - current_time))
+                        if total_duration > 0:
+                            timestamps["end"] = int(now + (total_duration - current_time))
                     elif isinstance(end_val, (int, float)):
                         timestamps["end"] = int(end_val)
             else:

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -274,12 +274,21 @@ function attachListeners() {
         videoElement = video;
         video.dataset.lastSrc = video.currentSrc;
 
-        const triggerSync = () => sendToBackground(video.paused ? "VIDEO_PAUSED" : "VIDEO_RESUMED");
+        if (video._rpcPlayHandler) video.removeEventListener('play', video._rpcPlayHandler);
+        if (video._rpcPauseHandler) video.removeEventListener('pause', video._rpcPauseHandler);
+        if (video._rpcSeekedHandler) video.removeEventListener('seeked', video._rpcSeekedHandler);
+        if (video._rpcMetadataHandler) video.removeEventListener('loadedmetadata', video._rpcMetadataHandler);
 
-        video.removeEventListener('play', triggerSync);
-        video.removeEventListener('pause', triggerSync);
+        const triggerSync = () => sendToBackground(video.paused ? "VIDEO_PAUSED" : "VIDEO_RESUMED");
+        const pauseHandler = () => { if (!video.seeking) triggerSync(); };
+
+        video._rpcPlayHandler = triggerSync;
+        video._rpcPauseHandler = pauseHandler;
+        video._rpcSeekedHandler = triggerSync;
+        video._rpcMetadataHandler = triggerSync;
+
         video.addEventListener('play', triggerSync);
-        video.addEventListener('pause', () => { if (!video.seeking) triggerSync(); });
+        video.addEventListener('pause', pauseHandler);
         video.addEventListener('seeked', triggerSync);
         video.addEventListener('loadedmetadata', triggerSync);
 

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -149,7 +149,7 @@ async function checkBrowsingActivity() {
     }
 }
 
-async function sendToBackground(action) {
+function sendToBackground(action) {
     if (!isVideoPage()) return;
 
     const title = getCleanTitle();
@@ -163,7 +163,8 @@ async function sendToBackground(action) {
 
     const video = document.querySelector('video');
     const currentUrl = window.location.href;
-    const thumbnail = await getVideoThumbnail(currentUrl);
+    const ogMeta = document.querySelector('meta[property="og:image"]');
+    const thumbnail = (ogMeta && ogMeta.content) ? ogMeta.content : "youtube";
 
     const payload = {
         url: currentUrl,
@@ -360,11 +361,24 @@ async function handleNavigation() {
 
     if (!isVideoPage()) {
         checkBrowsingActivity();
+        return;
     }
 
     if (navigationPollInterval) clearInterval(navigationPollInterval);
+
+    // Attach listeners immediately so the loadedmetadata event can fire the first send
+    attachListeners();
+
+    // If metadata is already available, send immediately without waiting for a poll tick
+    const video = document.querySelector('video');
+    if (video && video.readyState >= 1 && getCleanTitle()) {
+        sendToBackground(video.paused ? "VIDEO_PAUSED" : "VIDEO_RESUMED");
+        return;
+    }
+
+    // Fall back to a rapid poll for when the page isn't ready yet
     let attempts = 0;
-    navigationPollInterval = setInterval(async () => {
+    navigationPollInterval = setInterval(() => {
         if (!isVideoPage()) {
             clearInterval(navigationPollInterval);
             navigationPollInterval = null;
@@ -382,7 +396,7 @@ async function handleNavigation() {
             navigationPollInterval = null;
         }
         attempts++;
-    }, 200);
+    }, 50);
 }
 
 document.addEventListener('yt-navigate-finish', handleNavigation);

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -234,7 +234,8 @@ function scheduleThumbnailUpgradeSync(action, payload) {
         };
 
         lastSentThumbnail = bestThumbnail;
-        browser.runtime.sendMessage({ action, payload: currentPayload });
+        const currentAction = video && video.paused ? "VIDEO_PAUSED" : "VIDEO_RESUMED"; // keep track of paused state so RPC doesn't show misleading info
+        browser.runtime.sendMessage({ action: currentAction, payload: currentPayload });
     }, delayMs));
 
     pendingThumbnailRefreshTimers.set(videoId, timers);

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -421,10 +421,11 @@ document.addEventListener("visibilitychange", () => {
 
 setInterval(() => {
     if (isVideoPage()) {
-        attachListeners();
+        const video = document.querySelector('video');
+        if (video && !video._rpcPlayHandler) attachListeners();
         checkMetadataConsistency();
     }
-}, 1000);
+}, 100);
 
 // Check for browsing activity every 1 second
 if (browsingActivityCheckInterval) clearInterval(browsingActivityCheckInterval);

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -173,7 +173,7 @@ async function sendToBackground(action) {
         author_avatar: authorData.avatar,
         thumbnail,
         time: video ? video.currentTime : 0,
-        duration: video ? video.duration : 0,
+        duration: (video && isFinite(video.duration) && video.duration > 0) ? video.duration : 0,
         timestamp: new Date().toISOString()
     };
 
@@ -229,7 +229,7 @@ function scheduleThumbnailUpgradeSync(action, payload) {
             author_avatar: getAuthorData().avatar || payload.author_avatar,
             thumbnail: bestThumbnail,
             time: video ? video.currentTime : payload.time,
-            duration: video ? video.duration : payload.duration,
+            duration: (video && isFinite(video.duration) && video.duration > 0) ? video.duration : payload.duration,
             timestamp: new Date().toISOString()
         };
 

--- a/Extension/Activities/Youtube/handler.js
+++ b/Extension/Activities/Youtube/handler.js
@@ -280,14 +280,19 @@ function attachListeners() {
         if (video._rpcMetadataHandler) video.removeEventListener('loadedmetadata', video._rpcMetadataHandler);
 
         const triggerSync = () => sendToBackground(video.paused ? "VIDEO_PAUSED" : "VIDEO_RESUMED");
-        const pauseHandler = () => { if (!video.seeking) triggerSync(); };
+        let debounceTimer = null;
+        const debouncedTriggerSync = () => {
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(() => triggerSync(), 150);
+        };
+        const pauseHandler = () => { if (!video.seeking) debouncedTriggerSync(); };
 
-        video._rpcPlayHandler = triggerSync;
+        video._rpcPlayHandler = debouncedTriggerSync;
         video._rpcPauseHandler = pauseHandler;
         video._rpcSeekedHandler = triggerSync;
         video._rpcMetadataHandler = triggerSync;
 
-        video.addEventListener('play', triggerSync);
+        video.addEventListener('play', debouncedTriggerSync);
         video.addEventListener('pause', pauseHandler);
         video.addEventListener('seeked', triggerSync);
         video.addEventListener('loadedmetadata', triggerSync);
@@ -400,13 +405,12 @@ document.addEventListener("visibilitychange", () => {
     }
 });
 
-// Check for video activity every 2 seconds
 setInterval(() => {
     if (isVideoPage()) {
         attachListeners();
         checkMetadataConsistency();
     }
-}, 2000);
+}, 1000);
 
 // Check for browsing activity every 1 second
 if (browsingActivityCheckInterval) clearInterval(browsingActivityCheckInterval);

--- a/Extension/Activities/YoutubeMusic/handler.js
+++ b/Extension/Activities/YoutubeMusic/handler.js
@@ -325,8 +325,7 @@ function setupVideoEventListeners() {
 
 	// Re-send once metadata loads so the correct duration replaces any zeroed placeholder
 	const metadataHandler = () => {
-		const queueItem = getQueueItem();
-		if (queueItem && lastSentPlaying !== null) {
+		if (getQueueItem() && getCleanTitle()) {
 			sendToBackground(isMusicCurrentlyPlaying() ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
 		}
 	};
@@ -350,9 +349,17 @@ async function handleNavigation() {
 	setupVideoEventListeners();
 	checkBrowsingActivity();
 
-	
+	// Try immediate send if the track data is already in the DOM
+	const queueItem = getQueueItem();
+	const title = queueItem ? getCleanTitle() : null;
+	if (title && queueItem) {
+		sendToBackground(isMusicCurrentlyPlaying() ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
+		return;
+	}
+
+	// Fall back to a rapid poll until the track data is ready
 	let attempts = 0;
-	const checkMetadata = setInterval(async () => {
+	const checkMetadata = setInterval(() => {
 		const queueItem = getQueueItem();
 		const title = queueItem ? getCleanTitle() : null;
 
@@ -361,7 +368,7 @@ async function handleNavigation() {
 			clearInterval(checkMetadata);
 		}
 		attempts++;
-	}, 200);
+	}, 50);
 }
 
 document.addEventListener('yt-navigate-finish', handleNavigation);

--- a/Extension/Activities/YoutubeMusic/handler.js
+++ b/Extension/Activities/YoutubeMusic/handler.js
@@ -21,6 +21,8 @@ let cachedInformationPopups = null;
 let cachedRpcYoutubeMusic = null;
 let playingTabHealthCheckInFlight = false;
 
+let playPauseDebounceTimer = null;
+
 async function refreshCachedSettings() {
 	try {
 		const { informationPopups, rpcYoutubeMusic } = await browser.storage.local.get(["informationPopups", "rpcYoutubeMusic"]);
@@ -313,6 +315,12 @@ function setupVideoEventListeners() {
 	if (video._ytmusicMetadataHandler) {
 		video.removeEventListener('loadedmetadata', video._ytmusicMetadataHandler);
 	}
+	if (video._ytmusicPlayHandler) {
+		video.removeEventListener('play', video._ytmusicPlayHandler);
+	}
+	if (video._ytmusicPauseHandler) {
+		video.removeEventListener('pause', video._ytmusicPauseHandler);
+	}
 
 	const seekHandler = () => {
 		const queueItem = getQueueItem();
@@ -331,6 +339,21 @@ function setupVideoEventListeners() {
 	};
 	video._ytmusicMetadataHandler = metadataHandler;
 	video.addEventListener('loadedmetadata', metadataHandler);
+
+	// Debounced play/pause so rapid toggling resolves to the final state
+	const debouncedPlayPause = () => {
+		clearTimeout(playPauseDebounceTimer);
+		playPauseDebounceTimer = setTimeout(() => {
+			if (getQueueItem() && getCleanTitle()) {
+				sendToBackground(isMusicCurrentlyPlaying() ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
+			}
+		}, 150);
+	};
+	const pauseHandler = () => { if (!video.seeking) debouncedPlayPause(); };
+	video._ytmusicPlayHandler = debouncedPlayPause;
+	video._ytmusicPauseHandler = pauseHandler;
+	video.addEventListener('play', debouncedPlayPause);
+	video.addEventListener('pause', pauseHandler);
 }
 
 async function handleNavigation() {
@@ -387,10 +410,11 @@ document.addEventListener("visibilitychange", () => {
 
 setInterval(() => {
 	if (getQueueItem()) {
+		const video = document.querySelector('video');
+		if (video && !video._ytmusicSeekHandler) setupVideoEventListeners();
 		checkMetadataConsistency();
-		setupVideoEventListeners();
 	}
-}, 1000);
+}, 100);
 
 if (ENABLE_PLAYING_TAB_HEALTH_CHECK) {
 	setInterval(() => {

--- a/Extension/Activities/YoutubeMusic/handler.js
+++ b/Extension/Activities/YoutubeMusic/handler.js
@@ -194,6 +194,8 @@ async function sendToBackground(action) {
 	const thumbnail = getThumbnailUrl() || "youtubemusic";
 	const currentTrackKey = getStableTrackKey();
 
+	const isNewTrack = currentTrackKey !== lastSentTrackKey;
+
 	const payload = {
 		url: currentUrl,
 		title,
@@ -202,7 +204,7 @@ async function sendToBackground(action) {
 		author_avatar: "youtubemusic",
 		thumbnail,
 		time: getCurrentTime(),
-		duration: getDuration(),
+		duration: isNewTrack ? 0 : getDuration(),
 		timestamp: new Date().toISOString(),
 	};
 
@@ -308,6 +310,9 @@ function setupVideoEventListeners() {
 		video.removeEventListener('timeupdate', video._ytmusicTimeUpdateHandler);
 		delete video._ytmusicTimeUpdateHandler;
 	}
+	if (video._ytmusicMetadataHandler) {
+		video.removeEventListener('loadedmetadata', video._ytmusicMetadataHandler);
+	}
 
 	const seekHandler = () => {
 		const queueItem = getQueueItem();
@@ -317,6 +322,16 @@ function setupVideoEventListeners() {
 	};
 	video._ytmusicSeekHandler = seekHandler;
 	video.addEventListener('seeked', seekHandler);
+
+	// Re-send once metadata loads so the correct duration replaces any zeroed placeholder
+	const metadataHandler = () => {
+		const queueItem = getQueueItem();
+		if (queueItem && lastSentPlaying !== null) {
+			sendToBackground(isMusicCurrentlyPlaying() ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
+		}
+	};
+	video._ytmusicMetadataHandler = metadataHandler;
+	video.addEventListener('loadedmetadata', metadataHandler);
 }
 
 async function handleNavigation() {

--- a/Extension/Activities/YoutubeMusic/handler.js
+++ b/Extension/Activities/YoutubeMusic/handler.js
@@ -182,7 +182,7 @@ async function checkBrowsingActivity() {
 	}
 }
 
-async function sendToBackground(action, isNewTrack = false) {
+async function sendToBackground(action) {
 	const queueItem = getQueueItem();
 	if (!queueItem) return;
 
@@ -201,8 +201,8 @@ async function sendToBackground(action, isNewTrack = false) {
 		author_url: authorData.url || "",
 		author_avatar: "youtubemusic",
 		thumbnail,
-		time: isNewTrack ? 0 : getCurrentTime(),
-		duration: isNewTrack ? getDuration() : getDuration(),
+		time: getCurrentTime(),
+		duration: getDuration(),
 		timestamp: new Date().toISOString(),
 	};
 
@@ -235,25 +235,20 @@ async function checkMetadataConsistency() {
 	const currentThumbnail = getThumbnailUrl();
 	const authorData = getAuthorData();
     const currentTrackKey = getStableTrackKey();
-	const currentTime = getCurrentTime();
-
 	const titleChanged = currentTitle !== lastSentTitle;
 	const urlChanged = currentUrl !== lastSentUrl;
 	const thumbnailChanged = (currentThumbnail || "") !== (lastSentThumbnail || "");
 	const authorChanged = (authorData.name || "") !== (lastSentAuthor || "") || (authorData.url || "") !== (lastSentAuthorUrl || "");
-	const timeChanged = Math.abs(currentTime - lastSentTime) > 3;
 
-	
 	const currentlyPlaying = isMusicCurrentlyPlaying();
 	const playStateChanged = lastSentPlaying !== null && currentlyPlaying !== lastSentPlaying;
 
-	
 	const isNewTrack = currentTrackKey !== lastSentTrackKey;
-	const hasSignificantChange = isNewTrack || playStateChanged || authorChanged || titleChanged || urlChanged || thumbnailChanged || (timeChanged && !isNewTrack);
+	const hasSignificantChange = isNewTrack || playStateChanged || authorChanged || titleChanged || urlChanged || thumbnailChanged;
 	const isDataValid = !!currentTitle;
 
 	if (hasSignificantChange && isDataValid) {
-		sendToBackground(currentlyPlaying ? "VIDEO_RESUMED" : "VIDEO_PAUSED", isNewTrack);
+		sendToBackground(currentlyPlaying ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
 
 		
 		if (informationPopups && isNewTrack) {
@@ -306,38 +301,22 @@ function setupVideoEventListeners() {
 	const video = document.querySelector('video');
 	if (!video) return;
 
-	// Remove existing listeners if any to avoid duplicates
 	if (video._ytmusicSeekHandler) {
 		video.removeEventListener('seeked', video._ytmusicSeekHandler);
 	}
 	if (video._ytmusicTimeUpdateHandler) {
 		video.removeEventListener('timeupdate', video._ytmusicTimeUpdateHandler);
+		delete video._ytmusicTimeUpdateHandler;
 	}
 
-	// Handle seeking - immediately update time
 	const seekHandler = () => {
 		const queueItem = getQueueItem();
 		if (queueItem && lastSentPlaying !== null) {
-			checkMetadataConsistency();
+			sendToBackground(isMusicCurrentlyPlaying() ? "VIDEO_RESUMED" : "VIDEO_PAUSED");
 		}
 	};
 	video._ytmusicSeekHandler = seekHandler;
 	video.addEventListener('seeked', seekHandler);
-
-	// Handle time updates - throttled to avoid excessive updates
-	let lastTimeUpdate = 0;
-	const timeUpdateHandler = () => {
-		const now = Date.now();
-		if (now - lastTimeUpdate > 5000) { // Only update every 5 seconds
-			lastTimeUpdate = now;
-			const queueItem = getQueueItem();
-			if (queueItem && lastSentPlaying !== null) {
-				checkMetadataConsistency();
-			}
-		}
-	};
-	video._ytmusicTimeUpdateHandler = timeUpdateHandler;
-	video.addEventListener('timeupdate', timeUpdateHandler);
 }
 
 async function handleNavigation() {
@@ -384,14 +363,12 @@ document.addEventListener("visibilitychange", () => {
 	setupVideoEventListeners();
 });
 
-// Check for track activity every 2 seconds
 setInterval(() => {
 	if (getQueueItem()) {
 		checkMetadataConsistency();
-		// Periodically ensure video listeners are attached
 		setupVideoEventListeners();
 	}
-}, 2000);
+}, 1000);
 
 if (ENABLE_PLAYING_TAB_HEALTH_CHECK) {
 	setInterval(() => {

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -1454,6 +1454,13 @@ setTimeout(() => {
     checkForNativeAppUpdate();
 }, 2000);
 
+// On background script startup, content scripts on already-open tabs still have
+// their old state and won't re-send unless asked. Kick a sync so the bridge gets
+// current activity without requiring the user to reload the tab.
+setTimeout(() => {
+    syncActiveTabs();
+}, 500);
+
 browser.runtime.onSuspend.addListener(() => {
     const port = getNativePort();
     if (port) port.postMessage({ action: "CLEAR_RPC" });

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -1274,19 +1274,17 @@ browser.tabs.onRemoved.addListener((tabId) => {
         const port = getNativePort();
         if (!port) return;
 
-        let selected = {};
+        port.postMessage({ action: "TAB_CLOSED", tabId: tabId });
+
         try {
             const status = await requestNativeStatus(700);
-            selected = (status && status.selected_tabs) || {};
+            const selected = (status && status.selected_tabs) || {};
+            Object.entries(selected).forEach(([service, selectedTabId]) => {
+                if (String(selectedTabId) === String(tabId)) {
+                    port.postMessage({ action: "CLEAR_SERVICE", service });
+                }
+            });
         } catch { }
-
-        Object.entries(selected).forEach(([service, selectedTabId]) => {
-            if (String(selectedTabId) === String(tabId)) {
-                port.postMessage({ action: "CLEAR_SERVICE", service });
-            }
-        });
-
-        port.postMessage({ action: "TAB_CLOSED", tabId: tabId });
     })();
 });
 

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -1878,7 +1878,7 @@ function warmupVersionInfo() {
 }
 
 function currentSectionMapping() {
-    mapping = {
+    const mapping = {
         youtube: "rpcYoutube",
         youtubeMusic: "rpcYoutubeMusic",
         custom: "rpcCustom"


### PR DESCRIPTION
- thumbnail refresh stale action: Just read video.paused fresh inside the timer rather than trusting whatever action was when the timer was created.
- event listener accumulation: Saved each handler onto the video element so the next call can actually find and remove the old ones before adding new ones.
- REFRESH ignoring paused state: Copied the same paused/running check that was already working for YouTube Music over to the regular YouTube branch.

