### PR TITLE
Fix RPC for songs with very short titles

### DIFF
--- a/Extension/Activities/Youtube/data.js
+++ b/Extension/Activities/Youtube/data.js
@@ -138,7 +138,7 @@ function detectPageType() {
 
 function getCleanTitle() {
   const raw = document.title || "";
-  const cleaned = raw
+  let cleaned = raw
     .replace(/^\(\d+\)\s/, "")
     .replace(/\s-\sYouTube$/i, "")
     .trim();
@@ -146,6 +146,8 @@ function getCleanTitle() {
   if (!cleaned || cleaned.toLowerCase() === "youtube") {
     return null;
   }
+
+  if (cleaned.length < 2) cleaned = cleaned + ' ';
 
   return cleaned;
 }

--- a/Extension/Activities/YoutubeMusic/data.js
+++ b/Extension/Activities/YoutubeMusic/data.js
@@ -63,12 +63,16 @@ function getCleanTitle() {
 	const queueItem = getQueueItem();
 	if (queueItem) {
 		const titleElement = queueItem.querySelector('.song-title');
-		const title = titleElement?.textContent?.trim();
-		if (title) return title;
+		let title = titleElement?.textContent?.trim();
+		if (title) {
+			if (title.length < 2) title = title + ' ';
+			return title;
+		}
 	}
 
-	const playerBarTitle = document.querySelector('ytmusic-player-bar .title, ytmusic-player-bar .content-info-wrapper .title')
+	let playerBarTitle = document.querySelector('ytmusic-player-bar .title, ytmusic-player-bar .content-info-wrapper .title')
 		?.textContent?.trim();
+	if (playerBarTitle && playerBarTitle.length < 2) playerBarTitle = playerBarTitle + ' ';
 	return playerBarTitle || null;
 }
 


### PR DESCRIPTION
Discord requires minimum 2 characters for details/state fields.
Titles like "+" were being rejected, causing presence to clear.
Pad titles under 2 chars with a space.

Example music:
https://music.youtube.com/watch?v=2FemKMeYB0A

Discord error:
```json
{
    "cmd": "SET_ACTIVITY",
    "data": {
        "code": 4000,
        "message": "child \"activity\" fails because [child \"details\" fails because [\"details\" length must be at least 2 characters long]]"
    },
    "evt": "ERROR",
}
```